### PR TITLE
fix: Incorrect ChainID for Ethereum Mainnet

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -11,5 +11,5 @@
   "VERSION": "mumbai",
   "NETWORK": "testnet",
   "MATIC_CHAINID": 80001,
-  "ETHEREUM_CHAINID": 5
+  "ETHEREUM_CHAINID": 1
 }


### PR DESCRIPTION
Chain ID was set to be 5. I believe the correct ID is 1, which is also being checked for by the react App. 

Source: https://chainid.network/